### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /.idea/
 /BUILD/
 /examples/.env/
+*.so
+spdlog/
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+testclient


### PR DESCRIPTION
Excludes shared library objects from build, CMake generated files
and "testclient" from examples.