### PR TITLE
Free the data ptr in OnSCTPForGS callback

### DIFF
--- a/src/SCTPWrapper.cpp
+++ b/src/SCTPWrapper.cpp
@@ -169,7 +169,7 @@ int SCTPWrapper::OnSCTPForGS(struct socket *sock, union sctp_sockstore addr, voi
     std::cout << "Got msg of size: " << len << "\n";
     OnMsgReceived((const uint8_t *)data, len, recv_info.rcv_sid, ntohl(recv_info.rcv_ppid));
   }
-
+  free(data);
   return 0;
 }
 


### PR DESCRIPTION
This fixes the last of all the prominent leaks in my valgrind test.