### PR TITLE
Implement datachannel close

### DIFF
--- a/include/rtcdcpp/DataChannel.hpp
+++ b/include/rtcdcpp/DataChannel.hpp
@@ -45,6 +45,7 @@ namespace rtcdcpp {
 #define PPID_BINARY_EMPTY 57
 
 // DataChannel Control Types
+#define DC_TYPE_CLOSE 0x04
 #define DC_TYPE_OPEN 0x03
 #define DC_TYPE_ACK 0x02
 

--- a/include/rtcdcpp/PeerConnection.hpp
+++ b/include/rtcdcpp/PeerConnection.hpp
@@ -150,10 +150,13 @@ class PeerConnection {
 
   // DataChannel message parsing
   void HandleNewDataChannel(ChunkPtr chunk, uint16_t sid);
+  void HandleDataChannelClose(uint16_t sid);
   void HandleStringMessage(ChunkPtr chunk, uint16_t sid);
   void HandleBinaryMessage(ChunkPtr chunk, uint16_t sid);
 
   std::shared_ptr<Logger> logger = GetLogger("rtcdcpp.PeerConnection");
+ public:
+  void ResetSCTPStream(uint16_t stream_id);
 
 };
 }

--- a/include/rtcdcpp/PeerConnection.hpp
+++ b/include/rtcdcpp/PeerConnection.hpp
@@ -56,6 +56,7 @@ struct RTCConfiguration {
 };
 
 class PeerConnection {
+  friend class DataChannel;
  public:
   struct IceCandidate {
     IceCandidate(const std::string &candidate, const std::string &sdpMid, int sdpMLineIndex)
@@ -155,8 +156,6 @@ class PeerConnection {
   void HandleBinaryMessage(ChunkPtr chunk, uint16_t sid);
 
   std::shared_ptr<Logger> logger = GetLogger("rtcdcpp.PeerConnection");
- public:
-  void ResetSCTPStream(uint16_t stream_id);
-
+  void ResetSCTPStream(uint16_t stream_id, uint16_t srs_flags);
 };
 }

--- a/include/rtcdcpp/PeerConnection.hpp
+++ b/include/rtcdcpp/PeerConnection.hpp
@@ -156,6 +156,6 @@ class PeerConnection {
   void HandleBinaryMessage(ChunkPtr chunk, uint16_t sid);
 
   std::shared_ptr<Logger> logger = GetLogger("rtcdcpp.PeerConnection");
-  void ResetSCTPStream(uint16_t stream_id, uint16_t srs_flags);
+  void ResetSCTPStream(uint16_t stream_id);
 };
 }

--- a/include/rtcdcpp/SCTPWrapper.hpp
+++ b/include/rtcdcpp/SCTPWrapper.hpp
@@ -54,7 +54,7 @@ class SCTPWrapper {
   bool Initialize();
   void Start();
   void Stop();
-  void ResetSCTPStream(uint16_t stream_id);
+  void ResetSCTPStream(uint16_t stream_id, uint16_t srs_flags);
   //  int GetStreamCursor();
   //  void SetStreamCursor(int i);
 

--- a/include/rtcdcpp/SCTPWrapper.hpp
+++ b/include/rtcdcpp/SCTPWrapper.hpp
@@ -54,6 +54,7 @@ class SCTPWrapper {
   bool Initialize();
   void Start();
   void Stop();
+  void ResetSCTPStream(uint16_t stream_id);
   //  int GetStreamCursor();
   //  void SetStreamCursor(int i);
 

--- a/src/DataChannel.cpp
+++ b/src/DataChannel.cpp
@@ -59,7 +59,7 @@ std::string DataChannel::GetProtocol() { return this->protocol; }
 /**
  * Close the DataChannel.
  */
-void Close() { 
+void DataChannel::Close() { 
   this->pc->ResetSCTPStream(GetStreamID());
 }
 

--- a/src/DataChannel.cpp
+++ b/src/DataChannel.cpp
@@ -46,7 +46,7 @@ DataChannel::DataChannel(PeerConnection *pc, uint16_t stream_id, uint8_t chan_ty
   error_cb = [](std::string x) { ; };
 }
 
-DataChannel::~DataChannel() { ; }
+DataChannel::~DataChannel() { DataChannel::Close(); }
 
 uint16_t DataChannel::GetStreamID() { return this->stream_id; }
 
@@ -57,9 +57,11 @@ std::string DataChannel::GetLabel() { return this->label; }
 std::string DataChannel::GetProtocol() { return this->protocol; }
 
 /**
- * TODO: Close the DataChannel.
+ * Close the DataChannel.
  */
-void Close() { ; }
+void Close() { 
+  this->pc->ResetSCTPStream(GetStreamID());
+}
 
 bool DataChannel::SendString(std::string msg) {
   std::cerr << "DC: Sending string: " << msg << std::endl;

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -275,13 +275,23 @@ void PeerConnection::HandleBinaryMessage(ChunkPtr chunk, uint16_t sid) {
 }
 
 void PeerConnection::SendStrMsg(std::string str_msg, uint16_t sid) {
-  auto cur_msg = std::make_shared<Chunk>((const uint8_t *)str_msg.c_str(), str_msg.size());
-  this->sctp->GSForSCTP(cur_msg, sid, PPID_STRING);
+  auto chan = GetChannel(sid);
+  if (chan) {
+    auto cur_msg = std::make_shared<Chunk>((const uint8_t *)str_msg.c_str(), str_msg.size());
+    this->sctp->GSForSCTP(cur_msg, sid, PPID_STRING);
+  } else {
+    throw runtime_error("Datachannel does not exist");
+  }
 }
 
 void PeerConnection::SendBinaryMsg(const uint8_t *data, int len, uint16_t sid) {
-  auto cur_msg = std::make_shared<Chunk>(data, len);
-  this->sctp->GSForSCTP(cur_msg, sid, PPID_BINARY);
+  auto chan = GetChannel(sid);
+  if (chan) {
+    auto cur_msg = std::make_shared<Chunk>(data, len);
+    this->sctp->GSForSCTP(cur_msg, sid, PPID_BINARY);
+  } else {
+    throw runtime_error("Datachannel does not exist");
+  }
 }
 
 void PeerConnection::ResetSCTPStream(uint16_t stream_id) {

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -285,7 +285,7 @@ void PeerConnection::SendBinaryMsg(const uint8_t *data, int len, uint16_t sid) {
 }
 
 void PeerConnection::ResetSCTPStream(uint16_t stream_id) {
-  this->sctp->ResetSCTPStream(stream_id);
+  this->sctp->ResetSCTPStream(stream_id, SCTP_STREAM_RESET_OUTGOING);
 }
 
 }

--- a/src/SCTPWrapper.cpp
+++ b/src/SCTPWrapper.cpp
@@ -105,7 +105,7 @@ void SCTPWrapper::OnNotification(union sctp_notification *notify, size_t len) {
         uint16_t set_flags;
         if (reset_event.strreset_flags != 0) {
           if ((reset_event.strreset_flags ^ SCTP_STREAM_RESET_INCOMING_SSN) == 0) {
-            set_flags = SCTP_STREAM_RESET_INCOMING;  
+            set_flags = SCTP_STREAM_RESET_OUTGOING;  
           }
           if ((reset_event.strreset_flags ^ SCTP_STREAM_RESET_OUTGOING_SSN) == 0) {
             //fires when we close the stream from our side explicity or
@@ -126,7 +126,7 @@ void SCTPWrapper::OnNotification(union sctp_notification *notify, size_t len) {
         } else {
           continue;
         }
-        if (set_flags == SCTP_STREAM_RESET_INCOMING) {
+        if (set_flags == SCTP_STREAM_RESET_OUTGOING) {
           // Reset the stream when a remote close is received.
           logger->info("SCTP Reset received for stream_id#{} from remote", streamid);
           ResetSCTPStream(streamid + 1, set_flags);

--- a/src/SCTPWrapper.cpp
+++ b/src/SCTPWrapper.cpp
@@ -344,14 +344,79 @@ void SCTPWrapper::ResetSCTPStream(uint16_t stream_id, uint16_t srs_flags) {
   stream_close.srs_number_streams = no_of_streams;
   stream_close.srs_stream_list[0] = stream_id;
   if (usrsctp_setsockopt(this->sock, IPPROTO_SCTP, SCTP_RESET_STREAMS, &stream_close, (socklen_t)len) == -1) {
-    logger->error("Could not set socket options for SCTP_RESET_STREAMS. errno={}", errno); 
+    logger->error("Could not set socket options for SCTP_RESET_STREAMS for sid {}. errno={}", sid, errno); 
   } else {
-    logger->info("SCTP_RESET_STREAMS socket option has been set successfully");
+    logger->info("SCTP_RESET_STREAMS socket option has been set successfully for SID {}", stream_id);
   }
 }
 
 void SCTPWrapper::DTLSForSCTP(ChunkPtr chunk) { this->recv_queue.push(chunk); }
 
+uint16_t SCTPWrapper::GetSid(){
+    return this->sid;
+  }
+
+dc_open_msg* SCTPWrapper::GetDataChannelData(){
+  return this->data;
+  }
+
+std::string SCTPWrapper::GetLabel(){
+  return this->label;
+  }
+std::string SCTPWrapper::GetProtocol(){
+  return this->label;
+  }
+void SCTPWrapper::SetDataChannelSID(uint16_t sid)
+  {
+    this->sid = sid;
+  }
+void SCTPWrapper::SendACK() {
+    struct sctp_sndinfo sinfo = {0}; //
+    sinfo.snd_sid = GetSid();
+    sinfo.snd_ppid = htonl(PPID_CONTROL); 
+    uint8_t payload = DC_TYPE_ACK;
+    if (usrsctp_sendv(this->sock, &payload, sizeof(uint8_t), NULL, 0, &sinfo, sizeof(sinfo), SCTP_SENDV_SNDINFO, 0) < 0) {
+      logger->error("Sending ACK failed");
+      throw std::runtime_error("Sending ACK failed");
+    } else {
+      logger->info("Ack has gone through, SID: {}", sid);
+    }
+}
+void SCTPWrapper::CreateDCForSCTP(std::string label, std::string protocol) {
+
+  std::unique_lock<std::mutex> l2(createDCMtx);
+  while (!this->readyDataChannel) {
+    createDC.wait(l2);
+  }
+  struct sctp_sndinfo sinfo = {0};
+  int sid;
+  sid = this->sid;
+  sinfo.snd_sid = sid;
+  sinfo.snd_ppid = htonl(PPID_CONTROL); 
+
+  int total_size = sizeof *this->data + label.size() + protocol.size() - (2 * sizeof(char *));
+  this->data = (dc_open_msg *)calloc(1, total_size);
+  this->data->msg_type = DC_TYPE_OPEN;
+  this->data->chan_type = DATA_CHANNEL_RELIABLE;
+  this->data->priority = htons(0); // https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-10#section-6.4
+  this->data->reliability = htonl(0);
+  this->data->label_len = htons(label.length());
+  this->data->protocol_len = htons(protocol.length());
+  // try to overwrite last two char* from the struct
+  memcpy(&this->data->label, label.c_str(), label.length());
+  memcpy(&this->data->label + label.length(), protocol.c_str(), protocol.length());
+
+  this->label = label.c_str();
+  this->protocol = protocol.c_str();
+
+  if (started) {
+    if (usrsctp_sendv(this->sock, this->data, total_size, NULL, 0, &sinfo, sizeof(sinfo), SCTP_SENDV_SNDINFO, 0) < 0) {
+      logger->error("Failed to send a datachannel open request.");
+    } else {
+      logger->info("Datachannel open request has gone through.");
+    }
+  }
+}
 // Send a message to the remote connection
 void SCTPWrapper::GSForSCTP(ChunkPtr chunk, uint16_t sid, uint32_t ppid) {
   struct sctp_sendv_spa spa = {0};

--- a/src/SCTPWrapper.cpp
+++ b/src/SCTPWrapper.cpp
@@ -100,7 +100,12 @@ void SCTPWrapper::OnNotification(union sctp_notification *notify, size_t len) {
       SPDLOG_TRACE(logger, "OnNotification(type=SCTP_STREAM_RESET_EVENT)");
       struct sctp_stream_reset_event reset_event;
       reset_event = notify->sn_strreset_event;
-      for (int i = 1; i < 2; i++) {
+      uint32_t e_length;
+      e_length = reset_event.strreset_length;
+      size_t list_len;
+      list_len = e_length - (sizeof(uint16_t) * 2 + sizeof(uint32_t) + sizeof(sctp_assoc_t));
+      list_len /= sizeof(uint16_t);
+      for (int i = 1; i <= list_len; i++) {
         uint16_t streamid = reset_event.strreset_stream_list[i];
         uint16_t set_flags;
         if (reset_event.strreset_flags != 0) {


### PR DESCRIPTION
Works most of the time, but I've had instances where it doesn't seem to fire the event corresponding to `SCTP_STREAM_RESET_OUTGOING_SSN` flag and thus the final "on close" callback wouldn't be fired.