### PR TITLE
Add sleep in WebSocket poll

### DIFF
--- a/examples/websocket_client/WebSocketWrapper.cpp
+++ b/examples/websocket_client/WebSocketWrapper.cpp
@@ -1,5 +1,5 @@
 #include "WebSocketWrapper.hpp"
-
+#include <thread>
 #include <iostream>
 
 using namespace rtcdcpp;
@@ -23,7 +23,7 @@ void WebSocketWrapper::Start() {
 void WebSocketWrapper::Loop() {
   while (!this->stopping) {
     this->ws->poll();
-
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
     if (!this->send_queue.empty()) {
       ChunkPtr chunk = this->send_queue.wait_and_pop();
       std::string msg(reinterpret_cast<char const*>(chunk->Data()), chunk->Length());

--- a/examples/websocket_client/WebSocketWrapper.cpp
+++ b/examples/websocket_client/WebSocketWrapper.cpp
@@ -23,7 +23,7 @@ void WebSocketWrapper::Start() {
 void WebSocketWrapper::Loop() {
   while (!this->stopping) {
     this->ws->poll();
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     if (!this->send_queue.empty()) {
       ChunkPtr chunk = this->send_queue.wait_and_pop();
       std::string msg(reinterpret_cast<char const*>(chunk->Data()), chunk->Length());


### PR DESCRIPTION
CPU usage for the testclient was 100% because it was in a hot loop. I added a 500ms delay. Feel free to modify this as you'd like.