### PR TITLE
Define header for std::function

### DIFF
--- a/include/rtcdcpp/DataChannel.hpp
+++ b/include/rtcdcpp/DataChannel.hpp
@@ -32,7 +32,7 @@
 #pragma once
 
 #include "Chunk.hpp"
-
+#include <functional>
 #include <string>
 
 namespace rtcdcpp {


### PR DESCRIPTION
This fixed some compiler error after I upgraded my gcc I guess.